### PR TITLE
Add diodeinc/pcb-action/setup action

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -1,0 +1,20 @@
+name: "Setup PCB CLI"
+description: "Install the pcb CLI tool on the runner"
+author: "Diode Inc."
+
+inputs:
+  version:
+    description: "Version of pcb CLI to install (default: latest)"
+    required: false
+    default: "v0.2.0-prerelease.7"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install pcb CLI
+      shell: bash
+      run: |
+        curl --proto '=https' --tlsv1.2 -LsSf https://github.com/diodeinc/pcb/releases/download/${{ inputs.version }}/pcb-installer.sh | sh
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        export PATH="$HOME/.cargo/bin:$PATH"
+        pcb --version

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: "Version of pcb CLI to install (default: latest)"
     required: false
-    default: "v0.2.0-prerelease.7"
+    default: "latest"
 
 runs:
   using: "composite"
@@ -14,7 +14,11 @@ runs:
     - name: Install pcb CLI
       shell: bash
       run: |
-        curl --proto '=https' --tlsv1.2 -LsSf https://github.com/diodeinc/pcb/releases/download/${{ inputs.version }}/pcb-installer.sh | sh
+        if [ "${{ inputs.version }}" = "latest" ]; then
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/diodeinc/pcb/releases/latest/download/pcb-installer.sh | sh
+        else
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/diodeinc/pcb/releases/download/${{ inputs.version }}/pcb-installer.sh | sh
+        fi
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
         export PATH="$HOME/.cargo/bin:$PATH"
         pcb --version


### PR DESCRIPTION
This is useful as a lower-level reusable block. Can use it in multiple workflows with:

```
- name: Install PCB
  uses: diodeinc/pcb-action/setup@v2
```