### PR TITLE
Add detect, release, sign actions

### DIFF
--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -5,79 +5,56 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   detect:
     name: Detect boards
     runs-on: ubuntu-latest
     outputs:
-      boards: ${{ steps.discover.outputs.boards }}
+      boards: ${{ steps.detect.outputs.boards }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      - name: Discover .zen board files
-        id: discover
-        shell: bash
-        run: |
-          set -euo pipefail
-          BOARDS_JSON=$(python3 -c "import glob, json; print(json.dumps(sorted(glob.glob('boards/*/*.zen'))))")
-          if [ -z "${BOARDS_JSON}" ] || [ "${BOARDS_JSON}" = "[]" ]; then
-            echo "No boards found under boards/*/*.zen" >&2
-            exit 1
-          fi
-          echo "Found boards: ${BOARDS_JSON}"
-          echo "boards=${BOARDS_JSON}" >> "$GITHUB_OUTPUT"
+      - name: Install pcb
+        uses: diodeinc/pcb-action/setup@97d21fc143d97e517081b054a30dc76f979d737e
+
+      - name: Detect boards
+        id: detect
+        uses: diodeinc/pcb-action/detect@97d21fc143d97e517081b054a30dc76f979d737e
 
   release:
     name: Release ${{ matrix.board }}
     needs: detect
     runs-on: ubuntu-latest
+    container:
+      image: kicad/kicad:9.0.3
+      options: --user root
     strategy:
       fail-fast: false
       matrix:
         board: ${{ fromJSON(needs.detect.outputs.boards) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      - name: Derive board name
-        id: names
-        shell: bash
-        run: |
-          set -euo pipefail
-          b="${{ matrix.board }}"
-          name="$(basename "$(dirname "$b")")"
-          echo "board_name=$name" >> "$GITHUB_OUTPUT"
+      - name: Install dependencies
+        run: apt-get update && apt-get install -y curl jq git
 
-      - name: Run PCB release
+      - name: Fix git permissions
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: Install pcb
+        uses: diodeinc/pcb-action/setup@97d21fc143d97e517081b054a30dc76f979d737e
+
+      - name: Release
         id: release
-        uses: diodeinc/pcb-action@v1
+        uses: diodeinc/pcb-action/release@97d21fc143d97e517081b054a30dc76f979d737e
         with:
-          file: ${{ matrix.board }}
+          board: ${{ matrix.board }}
 
-      - name: Normalize archive path for host
-        id: norm
-        shell: bash
-        run: |
-          set -euo pipefail
-          p='${{ steps.release.outputs.archive }}'
-          # Strip container workspace prefix if present
-          p="${p#/github/workspace/}"
-          echo "path=${p}" >> "$GITHUB_OUTPUT"
-
-      - name: Sanitize version for artifact name
-        id: sanitize
-        shell: bash
-        run: |
-          set -euo pipefail
-          version='${{ steps.release.outputs.version }}'
-          # Replace forward slashes with hyphens for valid artifact name
-          sanitized_version="${version//\//-}"
-          echo "version=${sanitized_version}" >> "$GITHUB_OUTPUT"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - name: Sign
+        uses: diodeinc/pcb-action/sign@97d21fc143d97e517081b054a30dc76f979d737e
         with:
-          name: pcb-release-${{ steps.names.outputs.board_name }}-${{ steps.sanitize.outputs.version }}
-          path: ${{ steps.norm.outputs.path }}
+          path: ${{ steps.release.outputs.archive_path }}

--- a/detect/action.yml
+++ b/detect/action.yml
@@ -1,0 +1,18 @@
+name: "Detect PCB Boards"
+description: "Detect all PCB boards in the repository"
+author: "Diode Inc."
+
+outputs:
+  boards:
+    description: "JSON array of detected board names"
+    value: ${{ steps.discover.outputs.boards }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Discover boards
+      id: discover
+      shell: bash
+      run: |
+        pcb info -f json > pcb-info.json
+        echo "boards=$(jq -c '[.boards[].name]' pcb-info.json)" >> "$GITHUB_OUTPUT"

--- a/release/action.yml
+++ b/release/action.yml
@@ -1,0 +1,47 @@
+name: "PCB Release"
+description: "Create a PCB release archive with optional artifact upload"
+author: "Diode Inc."
+
+inputs:
+  board:
+    description: "Name of the board to release"
+    required: true
+  upload:
+    description: "Whether to upload the release archive as an artifact"
+    required: false
+    default: "true"
+
+outputs:
+  archive_path:
+    description: "Path to the created archive file"
+    value: ${{ steps.release.outputs.archive_name }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get Board Path
+      id: board-path
+      shell: bash
+      run: |
+        pcb info -f json > pcb-info.json
+        zen_path=$(jq -r --arg board "${{ inputs.board }}" '.boards[] | select(.name == $board) | .zen_path' pcb-info.json)
+        echo "zen_path=$zen_path" >> "$GITHUB_OUTPUT"
+
+    - name: PCB Release
+      id: release
+      shell: bash
+      run: |
+        pcb release ${{ steps.board-path.outputs.zen_path }} -f json --source-only > pcb-release.json
+        short_sha=$(git rev-parse --short HEAD)
+        archive_name="${{ inputs.board }}-$short_sha.zip"
+        cp $(jq -r '.archive' pcb-release.json) $archive_name
+        echo "archive_name=$archive_name" >> "$GITHUB_OUTPUT"
+        echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
+
+    - name: Upload Release Archive
+      if: inputs.upload == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: pcb-release-${{ inputs.board }}-${{ steps.release.outputs.short_sha }}
+        path: ${{ steps.release.outputs.archive_name }}
+        retention-days: 30

--- a/sign/action.yml
+++ b/sign/action.yml
@@ -1,0 +1,34 @@
+name: "Sign Release with Cosign"
+description: "Install cosign, sign the release file, and upload the cosign bundle"
+author: "Diode Inc."
+
+inputs:
+  path:
+    description: "Path to the file to sign"
+    required: true
+  upload:
+    description: "Whether to upload the cosign bundle as an artifact"
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v3.9.2
+
+    - name: Sign Release
+      id: sign
+      shell: bash
+      run: |
+        file_name=$(basename "${{ inputs.path }}")
+        cosign sign-blob "${{ inputs.path }}" --bundle "${file_name}.cosign.json" --yes
+        echo "bundle_name=${file_name}.cosign.json" >> "$GITHUB_OUTPUT"
+
+    - name: Upload Cosign Bundle
+      if: inputs.upload == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.sign.outputs.bundle_name }}.zip
+        path: "*.cosign.json"
+        retention-days: 30


### PR DESCRIPTION
Need to add the permissions block everwhere the `pcb-release.yml` reusable workflow is used.

```yaml
jobs:
  releases:
    permissions:
      contents: read
      id-token: write
    uses: diodeinc/pcb-action/.github/workflows/pcb-release.yml@v2
```

This uploads a consign bundle for each release:
<img width="704" height="376" alt="image" src="https://github.com/user-attachments/assets/92179410-b028-4914-a03f-0b59d29bcb33" />

the release can be verified with the bundle using the cosign cli:
```
> cosign verify-blob FMU-fe500b0.zip --bundle FMU-fe500b0.zip.cosign.json --certificate-oidc-issuer=https://token.actions.githubusercontent.com/ --certificate-identity-regexp='^https://github/\.com/diodeinc/pcb-action/.+$' --certificate-github-workflow-repository=diodeinc/boards

Verified OK
```

or the cosign js library: https://www.npmjs.com/package/sigstore.