### PR TITLE
Remove dependency on GH cli

### DIFF
--- a/label-boards/action.yml
+++ b/label-boards/action.yml
@@ -24,9 +24,17 @@ runs:
         set -e -o pipefail
 
         PR_NUMBER="${{ inputs.pr-number }}"
+        REPO="${GITHUB_REPOSITORY}"
+        API_ROOT="https://api.github.com/repos/${REPO}"
+
         if [[ -z "$PR_NUMBER" ]]; then
           echo "No PR number provided, skipping label update"
           exit 0
+        fi
+
+        if [[ -z "$GH_TOKEN" ]]; then
+          echo "GH_TOKEN is required to manage labels"
+          exit 1
         fi
 
         echo "Processing PR #$PR_NUMBER"
@@ -79,9 +87,40 @@ runs:
         # Add labels (create if they don't exist)
         for label in "${LABELS_TO_ADD[@]}"; do
           echo "Adding label: $label"
-          # Create label if it doesn't exist (ignore errors if it already exists)
-          gh label create "$label" --description "Changes to board ${label#board:}" --color "0366d6" 2>/dev/null || true
-          gh pr edit "$PR_NUMBER" --add-label "$label"
+          create_payload=$(jq -cn \
+            --arg name "$label" \
+            --arg description "Changes to board ${label#board:}" \
+            --arg color "0366d6" \
+            '{name: $name, description: $description, color: $color}')
+
+          create_response=$(curl -sS \
+            -X POST "${API_ROOT}/labels" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d "$create_payload" \
+            -w "\n%{http_code}")
+          create_status="${create_response##*$'\n'}"
+          if [[ "$create_status" != "201" && "$create_status" != "422" ]]; then
+            echo "Failed to create label $label (HTTP $create_status)"
+            echo "${create_response%$'\n'*}"
+            exit 1
+          fi
+
+          add_payload=$(jq -cn --arg label "$label" '{labels: [$label]}')
+          add_response=$(curl -sS \
+            -X POST "${API_ROOT}/issues/${PR_NUMBER}/labels" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d "$add_payload" \
+            -w "\n%{http_code}")
+          add_status="${add_response##*$'\n'}"
+          if [[ "$add_status" -lt 200 || "$add_status" -ge 300 ]]; then
+            echo "Failed to add label $label to PR #$PR_NUMBER (HTTP $add_status)"
+            echo "${add_response%$'\n'*}"
+            exit 1
+          fi
         done
 
         echo "Labels added successfully"

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -11,19 +11,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup GitHub CLI
-      uses: wusatosi/setup-gh@v1
-
     - name: Install pcb CLI
       shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
       run: |
         set -e -o pipefail
         if [ "${{ inputs.version }}" = "HEAD" ]; then
           # Download latest main build from prerelease
           mkdir -p ~/.cargo/bin
-          gh release download latest --repo diodeinc/pcb --pattern pcb --dir ~/.cargo/bin
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/diodeinc/pcb/releases/download/latest/pcb -o ~/.cargo/bin/pcb
           chmod +x ~/.cargo/bin/pcb
         elif [ "${{ inputs.version }}" = "latest" ]; then
           curl --proto '=https' --tlsv1.2 -LsSf https://github.com/diodeinc/pcb/releases/latest/download/pcb-installer.sh | sh


### PR DESCRIPTION
Because GitHub can't be trusted to reliably serve its own CLI for download. Seeing constant CI failures like this:

https://github.com/diodeinc/registry/actions/runs/22107722169/job/63895126372

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions automation for installing `pcb` and managing PR labels; main risk is CI failures if the GitHub API/curl handling is incorrect or token permissions differ from `gh` behavior.
> 
> **Overview**
> Removes the dependency on the GitHub CLI from the project’s composite GitHub Actions.
> 
> `setup/action.yml` no longer installs `gh` and, for `version=HEAD`, downloads the `pcb` binary directly from the GitHub release asset via `curl`.
> 
> `label-boards/action.yml` replaces `gh label create` / `gh pr edit` with direct GitHub REST API calls to create labels (treating 201/422 as success) and apply them to the PR, and now fails fast when `GH_TOKEN` is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09170780b8ea4f8701e935c5fb4afe16dc5fa5b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->