### PR TITLE
fix: `label-boards` pipe failure

### DIFF
--- a/label-boards/action.yml
+++ b/label-boards/action.yml
@@ -70,8 +70,8 @@ runs:
           BOARD_NAME=$(echo "$board_entry" | jq -r '.name')
           BOARD_PATH=$(echo "$board_entry" | jq -r '.path')
 
-          # Check if any changed file is within this board's path
-          if echo "$CHANGED_FILES" | grep -q "^${BOARD_PATH}/"; then
+          # Avoid SIGPIPE from grep -q short-circuiting a piped echo under pipefail.
+          if grep -q "^${BOARD_PATH}/" <<< "$CHANGED_FILES"; then
             echo "Board $BOARD_NAME has changes (path: $BOARD_PATH)"
             LABELS_TO_ADD+=("board:$BOARD_NAME")
           fi


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb-action/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small shell change that only affects how changed files are matched to board paths; low blast radius but could impact labeling if the match behavior differs in edge cases.
> 
> **Overview**
> Fixes occasional failures in the `label-boards` composite action caused by `set -o pipefail` treating `echo "$CHANGED_FILES" | grep -q ...` as an error when `grep -q` exits early.
> 
> The changed-file path check now uses a here-string (`grep -q ... <<< "$CHANGED_FILES"`) to avoid SIGPIPE while keeping the same board-label detection logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c009bd6ddb6b7928f73ed1cb83f6ec8e33fb20e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->