### PR TITLE
Install pcb from cf cdn

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -16,14 +16,14 @@ runs:
       run: |
         set -e -o pipefail
         if [ "${{ inputs.version }}" = "HEAD" ]; then
-          # Download latest main build from prerelease
           mkdir -p ~/.cargo/bin
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/diodeinc/pcb/releases/download/latest/pcb -o ~/.cargo/bin/pcb
+          curl --proto '=https' --tlsv1.2 -LsSf https://pcb.api.diode.computer/pcb/main/pcb -o ~/.cargo/bin/pcb
           chmod +x ~/.cargo/bin/pcb
         elif [ "${{ inputs.version }}" = "latest" ]; then
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/diodeinc/pcb/releases/latest/download/pcb-installer.sh | sh
+          curl --proto '=https' --tlsv1.2 -LsSf https://pcb.api.diode.computer/pcb/latest/pcb-installer.sh | sh
         else
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/diodeinc/pcb/releases/download/${{ inputs.version }}/pcb-installer.sh | sh
+          version="${{ inputs.version }}"
+          curl --proto '=https' --tlsv1.2 -LsSf "https://pcb.api.diode.computer/pcb/v${version#v}/pcb-installer.sh" | sh
         fi
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
         export PATH="$HOME/.cargo/bin:$PATH"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the download source and URL logic for installing `pcb` in CI, which could break builds or introduce supply-chain risk if the new endpoint is unavailable or misconfigured.
> 
> **Overview**
> Updates the `setup/action.yml` composite action to download/install the `pcb` CLI from `pcb.api.diode.computer` instead of GitHub releases for `HEAD`, `latest`, and versioned installs.
> 
> Versioned installs now normalize an optional leading `v` before constructing the installer URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cf84201a9f4ed59cdf68055ba47ae7a91ad4865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->